### PR TITLE
fix(cicd): release workflow runner timeout

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-stable
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
ubuntu-stable sometimes waits too long to find a runner, and then cancels

using ubuntu-latest instead