### PR TITLE
feat(cicd): move pytest args into config

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -63,5 +63,4 @@ jobs:
       - name: Run test suite
         env:
           PYTEST_NETWORK: mainnet
-        run: poetry run pytest -s -v
-      
+        run: poetry run pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,7 @@ pretty = true
 show_error_codes = true
 show_error_context = true
 strict = true
+
+[tool.pytest.ini_options]
+addopts = "-s -v"
+testpaths = ["tests"]


### PR DESCRIPTION
## Summary
- move pytest CLI flags into `pyproject.toml` config
- run pytest without inline args in workflow

## Testing
- not run (workflow change only)
