### PR TITLE
docs: drop remote-branch fetch requirement from AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,5 @@ All agents must follow these rules:
 9) Use one of `paths` or `paths-ignore` in every workflow file to make sure workflows only run when required.
 10) All mypy configuration (flags, overrides, per-module ignores, and file targets) should go in pyproject.toml. Do not split config across CLI args, mypy.ini, setup.cfg, or workflow steps.
 11) Centralize pytest settings (flags, markers, ignore patterns, and targets) in pyproject.toml, pytest.ini, setup.cfg, or tox.ini; workflows/hooks should call pytest without inline args.
-12) If the branch you're assigned to work on is from a remote (ie origin/master or upstream/awesome-feature) you must ensure you fetch and pull from the remote before you begin your work.
 
 Reference: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
## Summary
- remove the AGENTS rule requiring fetch/pull when working on remote branches

## Rationale
- avoid redundant setup steps and keep guidance aligned with current workflow

## Details
- delete the remote-branch fetch/pull requirement from `AGENTS.md`