### PR TITLE
fix: retry asyncio timeouts as transient failures

### DIFF
--- a/eth_retry/eth_retry.py
+++ b/eth_retry/eth_retry.py
@@ -226,6 +226,7 @@ def should_retry(e: Exception, failures: int, max_retries: int) -> bool:
         MaxRetryError,
         JSONDecodeError,
         ClientError,
+        AsyncioTimeoutError,
     )
 
     stre = str(e)


### PR DESCRIPTION
## Summary
- treat `AsyncioTimeoutError` as a retryable transient error in `should_retry`

## Rationale
Async IO timeouts should follow the same retry policy as other transient failures so callers can recover instead of failing immediately.

## Details
- add `AsyncioTimeoutError` to `general_exceptions` in `eth_retry/eth_retry.py`

## Testing
- `pytest` (timed out after 120s at `tests/unit/test_auto_retry_async.py::test_auto_retry_respects_max_retries_async` because master still has the async-timeout loop; resolved by PR #127)
