### PR TITLE
fix: stop retrying forbidden HTTP responses

### DIFF
--- a/eth_retry/conditional_imports.py
+++ b/eth_retry/conditional_imports.py
@@ -20,8 +20,9 @@ except ModuleNotFoundError:
 # aiohttp
 try:
     from aiohttp import ClientError
+    from aiohttp import ClientResponseError
 except ModuleNotFoundError:
-    ClientError = DummyException
+    ClientError, ClientResponseError = DummyException, DummyException
 
 # urllib
 try:

--- a/eth_retry/eth_retry.py
+++ b/eth_retry/eth_retry.py
@@ -14,6 +14,7 @@ import requests
 
 from eth_retry import ENVIRONMENT_VARIABLES as ENVS
 from eth_retry.conditional_imports import ClientError  # type: ignore
+from eth_retry.conditional_imports import ClientResponseError  # type: ignore
 from eth_retry.conditional_imports import HTTPError  # type: ignore
 from eth_retry.conditional_imports import MaxRetryError  # type: ignore
 from eth_retry.conditional_imports import OperationalError  # type: ignore
@@ -187,6 +188,8 @@ def should_retry(e: Exception, failures: int, max_retries: int) -> bool:
     if ETH_RETRY_DISABLED or failures > max_retries:
         return False
 
+    stre = str(e)
+
     retry_on_errs = (
         # Occurs on any chain when making computationally intensive calls. Just retry.
         # Sometimes works, sometimes doesn't. Worth a shot.
@@ -212,8 +215,13 @@ def should_retry(e: Exception, failures: int, max_retries: int) -> bool:
         # quicknode.com rate limiting
         "request limit reached - reduce calls per second or upgrade your account at quicknode.com",
     )
-    if any(filter(str(e).lower().__contains__, retry_on_errs)):  # type: ignore [arg-type]
+    if any(filter(stre.lower().__contains__, retry_on_errs)):  # type: ignore [arg-type]
         return True
+
+    if isinstance(e, HTTPError) and e.response is not None and e.response.status_code == 403:
+        return False
+    if isinstance(e, ClientResponseError) and e.status == 403:
+        return False
 
     general_exceptions = (
         ConnectionError,
@@ -226,7 +234,6 @@ def should_retry(e: Exception, failures: int, max_retries: int) -> bool:
         ClientError,
     )
 
-    stre = str(e)
     if (
         any(isinstance(e, E) for E in general_exceptions)
         and "Too Large" not in stre

--- a/tests/unit/test_should_retry.py
+++ b/tests/unit/test_should_retry.py
@@ -1,8 +1,24 @@
 from json import JSONDecodeError
 
 import pytest
+from aiohttp import RequestInfo
+from multidict import CIMultiDict, CIMultiDictProxy
+from yarl import URL
 
 import eth_retry.eth_retry as er
+
+
+def _http_error(status_code, message):
+    response = er.requests.Response()
+    response.status_code = status_code
+    return er.HTTPError(message, response=response)
+
+
+def _client_response_error(status_code, message):
+    headers = CIMultiDictProxy(CIMultiDict())
+    url = URL("https://example.com")
+    request_info = RequestInfo(url, "POST", headers, url)
+    return er.ClientResponseError(request_info, (), status=status_code, message=message)
 
 
 @pytest.mark.parametrize(
@@ -48,6 +64,28 @@ def test_should_retry_general_exceptions(exc):
 def test_should_retry_skips_too_large_and_404():
     assert er.should_retry(ConnectionError("Too Large"), failures=0, max_retries=3) is False
     assert er.should_retry(ConnectionError("404"), failures=0, max_retries=3) is False
+
+
+def test_should_retry_skips_403():
+    assert er.should_retry(_http_error(403, "Forbidden"), failures=0, max_retries=3) is False
+
+
+def test_should_retry_string_matches_before_skipping_403():
+    assert er.should_retry(_http_error(403, "Too Many Requests"), failures=0, max_retries=3) is True
+
+
+def test_should_retry_skips_aiohttp_403():
+    assert (
+        er.should_retry(_client_response_error(403, "Forbidden"), failures=0, max_retries=3)
+        is False
+    )
+
+
+def test_should_retry_string_matches_before_skipping_aiohttp_403():
+    assert (
+        er.should_retry(_client_response_error(403, "Too Many Requests"), failures=0, max_retries=3)
+        is True
+    )
 
 
 def test_should_retry_operational_error_locked():


### PR DESCRIPTION
Avoid wasting retry windows on non-transient 403 Forbidden responses while preserving retries for known rate-limit messages.